### PR TITLE
Compile the rust backend for both arm and x86

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -38,6 +38,11 @@ jobs:
             shell: cmd
     name: ${{ matrix.target_architecture }} on ${{ matrix.os }}
     steps:
+      - name: Install Rust Toolchains
+        if: matrix.os == 'macos-latest'
+        run: |
+          rustup target add x86_64-apple-darwin
+          rustup target add aarch64-apple-darwin
       - name: Install libusb
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install libusb-1.0-0-dev libudev-dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "node-sass": "^9.0.0",
         "plotly.js-basic-dist": "^2.11",
         "postcss-loader": "^6.2.1",
+        "run-script-os": "^1.1.6",
         "sass": "^1.50",
         "sass-loader": "^13.3.2",
         "style-loader": "^3.3.1",
@@ -8554,6 +8555,16 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+      "dev": true,
+      "bin": {
+        "run-os": "index.js",
+        "run-script-os": "index.js"
       }
     },
     "node_modules/rxjs": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "webpack-cli": "^4.9.2"
   },
   "scripts": {
-    "build-native": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node  -- cargo build --message-format=json-render-diagnostics",
+    "build-native-arm": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node.x86  -- cargo build --release --target=x86_64-apple-darwin --message-format=json-render-diagnostics",
+    "build-native-x86": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node.arm  -- cargo build --release --target=aarch64-apple-darwin --message-format=json-render-diagnostics",
+    "build-native": "npm run build-native-x86 && npm run build-native-arm && lipo -create -output app/nscope.node app/nscope.node.x86 app/nscope.node.arm",
     "build-app": "webpack --mode=production",
     "build": "npm run build-native && npm run build-app",
     "start": "electron-forge start",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node-sass": "^9.0.0",
     "plotly.js-basic-dist": "^2.11",
     "postcss-loader": "^6.2.1",
+    "run-script-os": "^1.1.6",
     "sass": "^1.50",
     "sass-loader": "^13.3.2",
     "style-loader": "^3.3.1",
@@ -34,9 +35,18 @@
     "webpack-cli": "^4.9.2"
   },
   "scripts": {
-    "build-native-arm": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node.x86  -- cargo build --release --target=x86_64-apple-darwin --message-format=json-render-diagnostics",
-    "build-native-x86": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node.arm  -- cargo build --release --target=aarch64-apple-darwin --message-format=json-render-diagnostics",
-    "build-native": "npm run build-native-x86 && npm run build-native-arm && lipo -create -output app/nscope.node app/nscope.node.x86 app/nscope.node.arm",
+    "build-x86_64-apple-darwin": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node.x86  -- cargo build --release --target=x86_64-apple-darwin --message-format=json-render-diagnostics",
+    "build-aarch64-apple-darwin": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node.arm  -- cargo build --release --target=aarch64-apple-darwin --message-format=json-render-diagnostics",
+    "build-universal-apple-darwin": "npm run build-x86_64-apple-darwin && npm run build-aarch64-apple-darwin && lipo -create -output app/nscope.node app/nscope.node.x86 app/nscope.node.arm && rm **/*.x86 **/*.arm",
+    "build-native:macos": "npm run build-universal-apple-darwin",
+
+    "build-x86_64-unknown-linux-gnu": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node  -- cargo build --release --target=x86_64-unknown-linux-gnu --message-format=json-render-diagnostics",
+    "build-native:linux": "npm run build-x86_64-unknown-linux-gnu",
+
+    "build-x86_64-pc-windows-msvc": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node  -- cargo build --release --target=x86_64-pc-windows-msvc --message-format=json-render-diagnostics",
+    "build-native:windows": "npm run build-x86_64-pc-windows-msvc",
+
+    "build-native": "run-script-os",
     "build-app": "webpack --mode=production",
     "build": "npm run build-native && npm run build-app",
     "start": "electron-forge start",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build-aarch64-apple-darwin": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node.arm  -- cargo build --release --target=aarch64-apple-darwin --message-format=json-render-diagnostics",
     "build-native:macos": "npm run build-x86_64-apple-darwin && npm run build-aarch64-apple-darwin && lipo -create -output app/nscope.node app/nscope.node.x86 app/nscope.node.arm && rm **/*.x86 **/*.arm",
 
-    "build-native:linux:windows": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node  -- cargo build --release --message-format=json-render-diagnostics",
+    "build-native:linux:win32": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node  -- cargo build --release --message-format=json-render-diagnostics",
     "build-native": "run-script-os",
 
     "build-app": "webpack --mode=production",

--- a/package.json
+++ b/package.json
@@ -37,18 +37,14 @@
   "scripts": {
     "build-x86_64-apple-darwin": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node.x86  -- cargo build --release --target=x86_64-apple-darwin --message-format=json-render-diagnostics",
     "build-aarch64-apple-darwin": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node.arm  -- cargo build --release --target=aarch64-apple-darwin --message-format=json-render-diagnostics",
-    "build-universal-apple-darwin": "npm run build-x86_64-apple-darwin && npm run build-aarch64-apple-darwin && lipo -create -output app/nscope.node app/nscope.node.x86 app/nscope.node.arm && rm **/*.x86 **/*.arm",
-    "build-native:macos": "npm run build-universal-apple-darwin",
+    "build-native:macos": "npm run build-x86_64-apple-darwin && npm run build-aarch64-apple-darwin && lipo -create -output app/nscope.node app/nscope.node.x86 app/nscope.node.arm && rm **/*.x86 **/*.arm",
 
-    "build-x86_64-unknown-linux-gnu": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node  -- cargo build --release --target=x86_64-unknown-linux-gnu --message-format=json-render-diagnostics",
-    "build-native:linux": "npm run build-x86_64-unknown-linux-gnu",
-
-    "build-x86_64-pc-windows-msvc": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node  -- cargo build --release --target=x86_64-pc-windows-msvc --message-format=json-render-diagnostics",
-    "build-native:windows": "npm run build-x86_64-pc-windows-msvc",
-
+    "build-native:linux:windows": "cargo-cp-artifact -ac nscope-nodejs app/nscope.node  -- cargo build --release --message-format=json-render-diagnostics",
     "build-native": "run-script-os",
+
     "build-app": "webpack --mode=production",
     "build": "npm run build-native && npm run build-app",
+
     "start": "electron-forge start",
     "dev": "concurrently -k \"webpack --watch --mode=development\" \"npm run build-native && electron . debug\"",
     "package": "electron-forge package",


### PR DESCRIPTION
This PR fixes an error in which the native backend code was not compiled for both x86 and arm architectures on macOS. Now we make sure to install both toolchains and create a fat binary library for distribution.