### PR TITLE
Update the README to not reference the develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,27 @@ nScope can be built and run from source to enable users and developers to quickl
 After installing the development dependencies, check to make sure you have a working environment by running version commands for each of the required tools.
 
 ```shell
+$ rustup --version
 $ cargo --version
 $ node --version
 $ npm --version
 ```
 The above commands should print a version successfully.
+
+###### macOS specifics
+On macOS the project is configured to build a universal binary, including both x86 and Apple Silicon binaries in one. To enable that, we must add both rust target toolchains as follows:
+```shell
+rustup target add x86_64-apple-darwin
+rustup target add aarch64-apple-darwin
+```
+
+###### Linux specific
+On linux distributions, we need the system library headers for `libusb` and `libudev`. To install these on an Ubuntu distribtion, the following command should work.
+```shell
+sudo apt-get install libusb-1.0-0-dev libudev-dev
+```
+On other distributions, developers should look to their package managers for these development headers. 
+
 
 ##### Clone and Install Development Dependencies
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ $ npm --version
 ```
 The above commands should print a version successfully.
 
-> **Note**
+> **Note** - macOS specifics
+> 
 > On macOS the project is configured to build a universal binary, including both x86 and Apple Silicon binaries in one. To enable that, we must add both rust target toolchains as follows:
 > ```shell
 > rustup target add x86_64-apple-darwin
 > rustup target add aarch64-apple-darwin
 > ```
 
-> **Note**
+> **Note** - Linux specifics
+> 
 > On linux distributions, we need the system library headers for `libusb` and `libudev`. To install these on an Ubuntu distribtion, the following command should work.
 > ```shell
 > sudo apt-get install libusb-1.0-0-dev libudev-dev

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 This version of nScope is based on the Electron framework. To use it, you must have the nScope hardware, updated to the latest version. Find more information about the hardware at https://www.nscope.org/
 
-### Pre-built Binaries
+## Pre-built Binaries
 
 Binaries are not yet distributed, but are built as part of the Github Actions pipelines. A release process in will be established in the near future to enable end users to download nScope without needing to access github.
 
-### Building from Source
+## Building from Source
 
 nScope can be built and run from source to enable users and developers to quickly iterate on nScope source code. To establish a development environment, follow the steps below.
 
-##### Prerequisites
+### Prerequisites
 
 1. Rust Toolchain (https://rustup.rs)
 2. Node Development Environment (https://nodejs.org/en/download)
@@ -25,22 +25,21 @@ $ npm --version
 ```
 The above commands should print a version successfully.
 
-###### macOS specifics
-On macOS the project is configured to build a universal binary, including both x86 and Apple Silicon binaries in one. To enable that, we must add both rust target toolchains as follows:
-```shell
-rustup target add x86_64-apple-darwin
-rustup target add aarch64-apple-darwin
-```
+> **Note**
+> On macOS the project is configured to build a universal binary, including both x86 and Apple Silicon binaries in one. To enable that, we must add both rust target toolchains as follows:
+> ```shell
+> rustup target add x86_64-apple-darwin
+> rustup target add aarch64-apple-darwin
+> ```
 
-###### Linux specific
-On linux distributions, we need the system library headers for `libusb` and `libudev`. To install these on an Ubuntu distribtion, the following command should work.
-```shell
-sudo apt-get install libusb-1.0-0-dev libudev-dev
-```
-On other distributions, developers should look to their package managers for these development headers. 
+> **Note**
+> On linux distributions, we need the system library headers for `libusb` and `libudev`. To install these on an Ubuntu distribtion, the following command should work.
+> ```shell
+> sudo apt-get install libusb-1.0-0-dev libudev-dev
+> ```
+> On other distributions, developers should look to their package managers for these development headers. 
 
-
-##### Clone and Install Development Dependencies
+### Clone and Install Development Dependencies
 
 ```shell
 $ git clone https://github.com/nLabs-nScope/nScope.git
@@ -48,7 +47,7 @@ $ cd nScope
 $ npm install
 ```
 
-##### Build and Run
+### Build and Run
 ```shell
 $ npm run build
 $ npm start

--- a/README.md
+++ b/README.md
@@ -2,14 +2,38 @@
 
 This version of nScope is based on the Electron framework. To use it, you must have the nScope hardware, updated to the latest version. Find more information about the hardware at https://www.nscope.org/
 
+### Pre-built Binaries
 
-This project is very much a work-in-progress. If you'd like to try out the latest and greatest, checkout the `develop` branch.
+Binaries are not yet distributed, but are built as part of the Github Actions pipelines. A release process in will be established in the near future to enable end users to download nScope without needing to access github.
 
+### Building from Source
 
-To install and run:
+nScope can be built and run from source to enable users and developers to quickly iterate on nScope source code. To establish a development environment, follow the steps below.
+
+##### Prerequisites
+
+1. Rust Toolchain (https://rustup.rs)
+2. Node Development Environment (https://nodejs.org/en/download)
+
+After installing the development dependencies, check to make sure you have a working environment by running version commands for each of the required tools.
+
+```shell
+$ cargo --version
+$ node --version
+$ npm --version
 ```
+The above commands should print a version successfully.
+
+##### Clone and Install Development Dependencies
+
+```shell
 $ git clone https://github.com/nLabs-nScope/nScope.git
 $ cd nScope
 $ npm install
+```
+
+##### Build and Run
+```shell
+$ npm run build
 $ npm start
 ```


### PR DESCRIPTION
This PR updates the main README to include a new set of instructions for getting a development environment installed.