### PR TITLE
polish up the UX in disconnected, power-fault, and sleep states

### DIFF
--- a/nscope.html
+++ b/nscope.html
@@ -35,18 +35,18 @@
                     <label class="btn btn-outline-secondary btn-xs shadow-none" for="stop">Stop</label>
                 </div>
                 <div id="nscope-power-usage-bar">
-                    <div class="btn btn-xs btn-outline-info" id="usb-status-bar"></div>
-                    <div id="nscope-power-usage">
+                    <div class="btn btn-xs btn-outline-info hidden" id="usb-status-bar"></div>
+                    <div class="hidden" id="nscope-power-usage">
                         <div class="btn btn-xs btn-info" id="usb-status"></div>
                     </div>
                     <div id="nscope-usb-power-off">
-                        <div class="btn btn-xs btn-outline-secondary">Power Off</div>
+                        <div class="btn btn-xs btn-outline-secondary hidden">Power Off</div>
                     </div>
                     <div id="nscope-usb-disconnected">
                         <div class="btn btn-xs btn-outline-danger">Disconnected</div>
                     </div>
                     <div id="nscope-usb-power-fault">
-                        <div class="btn btn-xs btn-outline-warning">Power Fault</div>
+                        <div class="btn btn-xs btn-outline-warning hidden">Power Fault</div>
                     </div>
                 </div>
             </div>
@@ -225,7 +225,9 @@
 
             </div>
             <div class="col bg-secondary p-0 flex-column d-flex overflow-hidden">
-                <div class="row h-100 w-100 g-0" id="glcanvas-div">
+                <div class="row h-100 w-100 g-0 position-relative align-items-center" id="scope-graph-container">
+                    <div class="h-100 w-100 position-absolute hidden" id="scope-graph"></div>
+                    <div class="bg-secondary text-white text-center fs-5 fw-light" id="scope-message" style="z-index: 1">Starting nScope...</div>
                 </div>
                 <div class="row w-100 bg-secondary border-top text-white py-1 g-0">
                     <div class="col-4 text-start px-4">
@@ -248,8 +250,8 @@
                     </div>
                     <div class="col-4 text-center">
                         <div class="btn-group static btn-group-xs" id="horizontal-info" role="group">
-                            <button type="button" class="btn btn-light" id="time-per-div"></button>
-                            <button type="button" class="btn btn-outline-light" id="sample-rate">Data Here</button>
+                            <button type="button" class="btn btn-light" id="time-per-div">1.0 s/div</button>
+                            <button type="button" class="btn btn-outline-light" id="sample-rate">4800 pts<br>400 Sa/s</button>
                         </div>
                     </div>
                     <div class="col-4 text-end px-4">
@@ -261,7 +263,6 @@
                     </div>
                 </div>
             </div>
-
             <div class="col bg-dark-1l sidebar">
                 <div class="btn-group-vertical btn-group-xs">
                     <div class="btn-group btn-group-xs">

--- a/nscope.html
+++ b/nscope.html
@@ -36,17 +36,17 @@
                 </div>
                 <div id="nscope-power-usage-bar">
                     <div class="btn btn-xs btn-outline-info hidden" id="usb-status-bar"></div>
-                    <div class="hidden" id="nscope-power-usage">
-                        <div class="btn btn-xs btn-info" id="usb-status"></div>
+                    <div id="nscope-power-usage">
+                        <div class="btn btn-xs btn-info hidden" id="usb-status"></div>
                     </div>
-                    <div id="nscope-usb-power-off">
-                        <div class="btn btn-xs btn-outline-secondary hidden">Power Off</div>
+                    <div class="hidden" id="nscope-usb-power-off">
+                        <div class="btn btn-xs btn-outline-secondary">Power Off</div>
                     </div>
                     <div id="nscope-usb-disconnected">
                         <div class="btn btn-xs btn-outline-danger">Disconnected</div>
                     </div>
-                    <div id="nscope-usb-power-fault">
-                        <div class="btn btn-xs btn-outline-warning hidden">Power Fault</div>
+                    <div class="hidden"  id="nscope-usb-power-fault">
+                        <div class="btn btn-xs btn-outline-warning">Power Fault</div>
                     </div>
                 </div>
             </div>

--- a/src/index.js
+++ b/src/index.js
@@ -79,11 +79,11 @@ for (let ch = 0; ch < 4; ch++) {
 function updatePlot() {
 
     let trace_data = nscope.getTraces(nScope);
-    Plotly.restyle('glcanvas-div', trace_data);
+    Plotly.restyle('scope-graph', trace_data);
     window.requestAnimationFrame(updatePlot);
 }
 
-Plotly.newPlot('glcanvas-div', traces, layout, {responsive: true, displayModeBar: false});
+Plotly.newPlot('scope-graph', traces, layout, {responsive: true, displayModeBar: false});
 
 
 function monitorScope() {

--- a/src/js/PowerStatus.js
+++ b/src/js/PowerStatus.js
@@ -12,6 +12,19 @@ function show(id) {
     element.classList.remove("hidden");
 }
 
+function message(msg_content) {
+    let msg = getId('scope-message');
+    if(msg_content == null) {
+        hide('scope-message');
+        show('scope-graph');
+    } else {
+        msg.innerHTML = msg_content
+        show('scope-message');
+        hide('scope-graph');
+    }
+}
+
+let previous_state = 'Unknown';
 export function update(powerState)
 {
     switch(powerState.state)
@@ -23,7 +36,7 @@ export function update(powerState)
             hide('nscope-usb-power-fault');
             hide('nscope-usb-disconnected');
             show('nscope-usb-power-off');
-
+            message('nScope is asleep');
             update.percentage = null;
             break;
         }
@@ -33,6 +46,7 @@ export function update(powerState)
             hide('nscope-usb-power-fault');
             hide('nscope-usb-disconnected');
 
+            message(null);
             show('usb-status-bar');
             show('usb-status');
             var percentage = powerState.usage*100/2.5;
@@ -43,9 +57,23 @@ export function update(powerState)
             getId('usb-status-bar').innerHTML = `${(update.percentage/100*2.5).toFixed(2)} W`;
             getId('usb-status').innerHTML = `${(update.percentage/100*2.5).toFixed(2)} W`;
 
+            if(previous_state !== "PowerOn"){
+                nscope.restartTraces(nScope);
+            }
             break;
         }
         case "Shorted":
+        {
+            hide('usb-status-bar');
+            hide('usb-status');
+            hide('nscope-usb-power-off');
+            hide('nscope-usb-disconnected');
+
+            show('nscope-usb-power-fault');
+            message('nScope detected a power fault');
+            update.percentage = null;
+            break;
+        }
         case "Overcurrent":
         {
             hide('usb-status-bar');
@@ -54,19 +82,22 @@ export function update(powerState)
             hide('nscope-usb-disconnected');
 
             show('nscope-usb-power-fault');
+            message('nScope detected an overcurrent event');
             update.percentage = null;
             break;
         }
-        default:
-        {
+        default: {
             hide('usb-status-bar');
             hide('usb-status');
             hide('nscope-usb-power-off');
             hide('nscope-usb-power-fault');
 
+
             show('nscope-usb-disconnected');
+            message('Cannot connect to nScope');
             update.percentage = null;
             break;
         }
     }
+    previous_state = powerState.state;
 }

--- a/src/js/Timing.js
+++ b/src/js/Timing.js
@@ -28,7 +28,6 @@ getId("horizontal-slider").oninput = function () {
 }
 
 export function initTiming() {
-    // console.log("Running!");
     getId("horizontal-slider").value = 0;
     getId("horizontal-slider").dispatchEvent(new Event('input'));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,18 @@ fn set_timing_parameters(mut cx: FunctionContext) -> JsResult<JsNull> {
     Ok(cx.null())
 }
 
+fn restart_traces(mut cx: FunctionContext) -> JsResult<JsNull> {
+    let js_nscope_handle = cx.argument::<JsNscopeHandle>(0)?;
+    let mut nscope_handle = js_nscope_handle.borrow_mut();
+
+    if nscope_handle.request_handle.is_some() {
+        nscope_handle.stop_request();
+        nscope_handle.traces.clear();
+    }
+
+    Ok(cx.null())
+}
+
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("version", version_string)?;
@@ -147,6 +159,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("getRunState", get_run_control)?;
     cx.export_function("setTimingParameters", set_timing_parameters)?;
     cx.export_function("getTraces", traces::get_traces)?;
+    cx.export_function("restartTraces", restart_traces)?;
 
     cx.export_function("getPxStatus", pulse_output::get_px_status)?;
     cx.export_function("setPxOn", pulse_output::set_px_on)?;

--- a/src/traces.rs
+++ b/src/traces.rs
@@ -46,6 +46,7 @@ impl NscopeTraces {
         for s in &mut self.samples {
             s.clear()
         }
+        self.current_head = 0;
     }
 }
 


### PR DESCRIPTION
This PR adds a message box overtop the main scope graph, so that when the nScope is not connected, or powered off the UI doesn't show erroneous data.