### PR TITLE
Resolve Issue 101: power usage bar not updating

### DIFF
--- a/src/js/PowerStatus.js
+++ b/src/js/PowerStatus.js
@@ -53,7 +53,7 @@ export function update(powerState) {
                 message(null);
                 show('usb-status-bar');
                 show('usb-status');
-                var percentage = powerState.usage * 100 / 2.5;
+                var percentage = Math.max(0, powerState.usage * 100 / 2.5);
                 update.percentage = (update.percentage || 0.0) * 0.8 + percentage * 0.2;
 
                 getId('nlab-power-usage').style.width = `${clamp(update.percentage, 0, 100)}%`;


### PR DESCRIPTION
Resolves issue #101, caused by a previously false optimization that prevented status from updating if the state of power did not change.